### PR TITLE
Some fixes and updates

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+/src/Components/svg/**/*

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,8 +8,6 @@
 	"parser": "babel-eslint",
 	"rules": {
 		"strict": 0,
-		"comma-dangle": [1, "always-multiline"],
-		"quotes": [1, "single"],
 		"no-underscore-dangle": 0,
 		"no-cond-assign": 0,
 		"no-unused-vars": [0, { "vars": "all", "args": "after-used", "ignoreRestSiblings": true }]

--- a/DemoComponent.jsx
+++ b/DemoComponent.jsx
@@ -21,31 +21,6 @@ export default class Demo extends Component {
 		};
 	}
 
-	componentDidMount() {
-		// console.log('mounted');
-		//const self = this;
-		//setTimeout(function () {
-		//    const newState = {
-		//        data: [
-		//            {text: "air-JA007D", win: "win-111", value: "JA007D"},
-		//            {text: "air-JA008D", win: "win-222", value: "JA008D"},
-		//            {text: "air-JA009D", win: "win-333", value: "JA009D"},
-		//            {text: "air-JA107D", win: "win-444", value: "JA010D"},
-		//            {text: "air-JA107R", win: "win-555", value: "JA107R"},
-		//            {text: "air-JA107Y", win: "win-666", value: "JA107Y"}
-		//        ]
-		//    };
-		//
-		//    newState.selectedValue = newState.data[5];
-		//
-		//    this.setState(newState, function() {
-		//        setTimeout(function() {
-		//            this.setState({selectedValue: newState.data[8]});
-		//        }.bind(self), 2000);
-		//    });
-		//}.bind(this), 2000);
-	}
-
 	fakeFunction(value, text) {
 		console.log('val:', value, 'txt:', text);
 	}
@@ -67,35 +42,6 @@ export default class Demo extends Component {
 	};
 
 	render() {
-		// var standardArray = ["DDD", "CCC", "BBB", "AAA"];
-		// var standardArray = [3, 1, 11, 111, 21, 33, 14, 32, 442];
-		// var standardArray = ["JA007D", "JA008D", "JA009D", "JA010D", "JA219J", "JA302J", "JA306J", "JA308J", "JA309J", "JA311J", "JA313J", "JA314J", "JA316J", "JA318J", "JA319J", "JA322J", "JA324J", "JA325J", "JA326J"];
-		// var standardArray = ["737-800", "767-300", "777-200", "777-300", "ERJ 170-100"];
-		// var standardArray = [];
-		// var standardArray = [
-		// 	{text: "air-JA007D", win: "win-JA007D", value: "JA007D"},
-		// 	{text: "air-JA008D", win: "win-JA008D", value: "JA008D"},
-		// 	{text: "air-JA009D", win: "win-JA009D", value: "JA009D"},
-		// 	{text: "air-JA107D", win: "win-JA107D", value: "JA010D"}
-		// ];
-		// var standardArray = [
-		// 	{text: 111, win: "win-JA009D", value: 111},
-		// 	{text: 3, win: "win-JA007D", value: 3},
-		// 	{text: 11, win: "win-JA0008D", value: 11},
-		// 	{text: 12, win: "win-JA107D", value: 12},
-		// 	{text: 13, win: "sin-JA101D", value: 13},
-		// 	{text: 14, win: "win-JA102D", value: 14},
-		// 	{text: 15, win: "win-JA103D", value: 15}
-		// ];
-
-		// var standardArray = [
-		//    {value: 'EFFECTIVE_DATE', text: 'Day'},
-		//    {value: 'EFFECTIVE_YEAR_WEEK', text: 'Week'},
-		//    {value: 'EFFECTIVE_YEAR_MONTH', text: 'Month'},
-		//    {value: 'EFFECTIVE_YEAR_QUARTER', text: 'Quarter'},
-		//    {value: 'EFFECTIVE_YEAR', text: 'Year'}
-		// ];
-
 		return (
 			<form action="">
 				<input type="text" required />
@@ -198,7 +144,7 @@ export default class Demo extends Component {
 						onChange={this.fakeFunction}
 						map={{ text: this.getText, value: this.getValue }}
 						onToggle={this.fakeToggle}
-						defaultText="Select Partner"
+						defaultText="Select Item"
 						ref={el => {
 							this.ComboRef5 = el;
 						}}

--- a/DemoComponent.jsx
+++ b/DemoComponent.jsx
@@ -128,12 +128,13 @@ export default class Demo extends Component {
 						preferredDirection="down"
 						sort="string"
 						search="smart"
+						text="Select Items"
+						defaultText="Select Item"
 						value={this.state.selectedGroupVals}
 						disabled={false}
 						onChange={this.fakeFunction}
 						map={{ text: this.getText, value: this.getValue }}
 						onToggle={this.fakeToggle}
-						defaultText="Select Partner"
 					/>
 				}
 

--- a/README.md
+++ b/README.md
@@ -241,9 +241,15 @@ Out of the box ComboSelect is using custom SVG icons that can be overriden by sp
 <ComboSelect icon="fa fa-chevron-down" iconSelectInactive="fa fa-circle-thin" iconSelectActive="fa fa-check" />
 ```
 
+### `resetValues` method
+
+Resets values in currently selected ComboSelect instance. You have an example og how to set it up in `DemoComponent.jsx`.
+
 ### Option groups
 
-Groups can be enabled by adding `groups` prop to the ComboSelect.
+Groups can be enabled by adding `groups` prop to the ComboSelect. They will work both in single select and in multiselect mode.
+
+> NOTE: For now, groups are only working with 'string' and 'number' sorting.
 
 ```javascript
 <ComboSelect type="multiselect" groups data={this.state.groups} />
@@ -252,8 +258,7 @@ Groups can be enabled by adding `groups` prop to the ComboSelect.
 Groups have to be passed down to component in specific format so that it can render properly. Initial data should look like this:
 
 ```js
-{
-{
+{ 
 	// Mandatory group name
 	groupName: 'Other',
 	// and array of options

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "enzyme": "^3.1.0",
     "enzyme-adapter-react-16": "^1.0.1",
     "eslint": "^4.18.1",
-    "eslint-plugin-react": "^4.2.3",
+    "eslint-plugin-react": "^7.10.0",
     "immutable": "^3.8.2",
     "jsdom": "^8.3.0",
     "mocha": "^4.0.1",

--- a/src/Components/ComboSelect.jsx
+++ b/src/Components/ComboSelect.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
@@ -90,15 +89,7 @@ export default class ComboSelect extends Component {
 		this.selectRef.removeEventListener('focusout', this.deSelectFocus);
 	}
 
-	// static getDerivedStateFromProps(nextProps, prevState) {
-	// 	return {
-
-	// 	};
-
-	// 	return null;
-	//   }
-
-	componentWillReceiveProps(newProps) {
+	UNSAFE_componentWillReceiveProps(newProps) {
 		if (newProps.text !== this.props.text || newProps.defaultText !== this.props.defaultText) {
 			this.defaultText = newProps.text ? newProps.text : newProps.defaultText ? newProps.defaultText : 'Select';
 		}

--- a/src/Components/ComboSelect.jsx
+++ b/src/Components/ComboSelect.jsx
@@ -99,9 +99,13 @@ export default class ComboSelect extends Component {
 	//   }
 
 	componentWillReceiveProps(newProps) {
-		if (newProps.data && newProps.value !== this.props.value) {
+		if (newProps.text !== this.props.text || newProps.defaultText !== this.props.defaultText) {
+			this.defaultText = newProps.text ? newProps.text : newProps.defaultText ? newProps.defaultText : 'Select';
+		}
+
+		if (newProps.data && newProps.value !== this.state.value) {
 			const mappedData = this.sortData(this.mapAllData(newProps.data));
-			const selectedItems = this.findSelectedItems(this.mappedData, newProps.text, newProps.value);
+			const selectedItems = this.findSelectedItems(mappedData, newProps.text, newProps.value);
 			this.processDataAttributes(newProps);
 
 			return this.setState({
@@ -109,9 +113,6 @@ export default class ComboSelect extends Component {
 				text: selectedItems.text,
 				value: selectedItems.value,
 			});
-		}
-		if (newProps.text !== this.props.text) {
-			this.defaultText = newProps.text ? newProps.text : newProps.defaultText ? newProps.defaultText : 'Select';
 		}
 	}
 

--- a/src/Components/svg/CircleIcon.jsx
+++ b/src/Components/svg/CircleIcon.jsx
@@ -3,13 +3,13 @@ import ReactSvgIcon, { disabledColor } from './ReactSvgIcon/index';
 
 export default class DropDownIcon extends Component {
 	render() {
-		return(
+		return (
 			<ReactSvgIcon className="SvgIconCircleIcon">
 				<path
 					fill={disabledColor}
 					d="M256,8C119,8,8,119,8,256s111,248,248,248s248-111,248-248S393,8,256,8z M256,456c-110.5,0-200-89.5-200-200S145.5,56,256,56s200,89.5,200,200S366.5,456,256,456z"
 				/>
 			</ReactSvgIcon>
-		)
+		);
 	}
 }

--- a/src/Components/svg/CircleIconChecked.jsx
+++ b/src/Components/svg/CircleIconChecked.jsx
@@ -3,13 +3,13 @@ import ReactSvgIcon, { enabledColor } from './ReactSvgIcon/index';
 
 export default class DropDownIcon extends Component {
 	render() {
-		return(
+		return (
 			<ReactSvgIcon className="SvgIconCircleIconChecked">
 				<path
 					fill={enabledColor}
 					d="M256,8C119,8,8,119,8,256s111,248,248,248s248-111,248-248S393,8,256,8z M396.1,203.2L223.5,374.4c-4.7,4.7-12.3,4.6-17-0.1l-90.8-91.5c-4.7-4.7-4.6-12.3,0.1-17l22.7-22.5c4.7-4.7,12.3-4.6,17,0.1l59.8,60.3l141.4-140.2c4.7-4.7,12.3-4.6,17,0.1l22.5,22.7C400.9,191,400.8,198.6,396.1,203.2z"
 				/>
 			</ReactSvgIcon>
-		)
+		);
 	}
 }

--- a/src/Components/svg/DropDownIcon.jsx
+++ b/src/Components/svg/DropDownIcon.jsx
@@ -3,13 +3,13 @@ import ReactSvgIcon, { enabledColor } from './ReactSvgIcon/index';
 
 export default class DropDownIcon extends Component {
 	render() {
-		return(
+		return (
 			<ReactSvgIcon className="SvgIconDropDownIcon">
 				<path
 					fill={enabledColor}
 					d="M504 256c0 137-111 248-248 248S8 393 8 256 119 8 256 8s248 111 248 248zM273 369.9l135.5-135.5c9.4-9.4 9.4-24.6 0-33.9l-17-17c-9.4-9.4-24.6-9.4-33.9 0L256 285.1 154.4 183.5c-9.4-9.4-24.6-9.4-33.9 0l-17 17c-9.4 9.4-9.4 24.6 0 33.9L239 369.9c9.4 9.4 24.6 9.4 34 0z"
 				/>
 			</ReactSvgIcon>
-		)
+		);
 	}
 }

--- a/src/Components/svg/SquareIcon.jsx
+++ b/src/Components/svg/SquareIcon.jsx
@@ -3,13 +3,13 @@ import ReactSvgIcon, { disabledColor } from './ReactSvgIcon/index';
 
 export default class DropDownIcon extends Component {
 	render() {
-		return(
+		return (
 			<ReactSvgIcon className="SvgIconSquareIcon">
 				<path
 					fill={disabledColor}
 					d="M432,32H80c-26.5,0-48,21.5-48,48v352c0,26.5,21.5,48,48,48h352c26.5,0,48-21.5,48-48V80C480,53.5,458.5,32,432,32z M432,432H80V80h352V432z"
 				/>
 			</ReactSvgIcon>
-		)
+		);
 	}
 }

--- a/src/Components/svg/SquareIconChecked.jsx
+++ b/src/Components/svg/SquareIconChecked.jsx
@@ -3,13 +3,13 @@ import ReactSvgIcon, { enabledColor } from './ReactSvgIcon/index';
 
 export default class DropDownIcon extends Component {
 	render() {
-		return(
+		return (
 			<ReactSvgIcon className="SvgIconSquareIconChecked">
 				<path
 					fill={enabledColor}
 					d="M432,32H80c-26.5,0-48,21.5-48,48v352c0,26.5,21.5,48,48,48h352c26.5,0,48-21.5,48-48V80C480,53.5,458.5,32,432,32z M396.1,190.3L223.5,361.5c-4.7,4.7-12.3,4.6-17-0.1l-90.8-91.5c-4.7-4.7-4.6-12.3,0.1-17l22.7-22.5c4.7-4.7,12.3-4.6,17,0.1l59.8,60.3l141.4-140.2c4.7-4.7,12.3-4.6,17,0.1l22.5,22.7C400.9,178,400.8,185.6,396.1,190.3L396.1,190.3z"
 				/>
 			</ReactSvgIcon>
-		)
+		);
 	}
 }

--- a/test/placeholderUpdate.test.js
+++ b/test/placeholderUpdate.test.js
@@ -10,33 +10,34 @@ import { expect } from 'chai';
 import { data as regularData } from './fixtures';
 
 describe('Placeholder updates', () => {
-	beforeEach(() => {
-		sinon.spy(ComboSelect.prototype, 'componentDidMount');
-	});
-
-	afterEach(() => {
-		ComboSelect.prototype.componentDidMount.restore();
-	});
-
+	let wrapper;
 	let data = [...regularData];
+	beforeEach(() => {
+		wrapper = mount(<ComboSelect data={data} />);
+		wrapper.setProps({ text: undefined, defaultText: undefined });
+	});
 
-	it('component updates placeholder when prop defaultText changes', () => {
-		const comboPlaceholder = 'First Placeholder';
-		const wrapper = mount(
-			<ComboSelect data={data} text={comboPlaceholder} map={{ text: 'text', value: true }} sort="string" />
-		);
-		expect(wrapper.find('.combo-select-head').text()).to.equal(comboPlaceholder);
-
-		const comboPlaceholder2 = 'Second Placeholder';
-		wrapper.setProps({ defaultText: comboPlaceholder2, text: null });
-		expect(wrapper.find('.combo-select-head').text()).to.equal(comboPlaceholder2);
-
-		const comboPlaceholder3 = 'Third Placeholder';
-		wrapper.setProps({ text: comboPlaceholder3, defaultText: null });
-		expect(wrapper.find('.combo-select-head').text()).to.equal(comboPlaceholder3);
-
+	it('should use text prop when both text and defaultText props are present', () => {
 		const comboPlaceholder4 = 'Fourth Placeholder';
 		wrapper.setProps({ text: comboPlaceholder4, defaultText: 'Select' });
+		wrapper.update();
+
 		expect(wrapper.find('.combo-select-head').text()).to.equal(comboPlaceholder4);
+	});
+
+	it('should use text prop when no defaultText prop is present', () => {
+		const comboPlaceholder3 = 'Third Placeholder';
+		wrapper.setProps({ text: comboPlaceholder3, defaultText: undefined, sort: 'smart' });
+		wrapper.update();
+
+		expect(wrapper.find('.combo-select-head').text()).to.equal(comboPlaceholder3);
+	});
+
+	it('should use defaultText if no text prop is present', () => {
+		const comboPlaceholder2 = 'Second Placeholder';
+		wrapper.setProps({ defaultText: comboPlaceholder2, text: undefined, type: 'multiselect' });
+		wrapper.update();
+
+		expect(wrapper.find('.combo-select-head').text()).to.equal(comboPlaceholder2);
 	});
 });

--- a/test/selectingValues.test.js
+++ b/test/selectingValues.test.js
@@ -78,6 +78,7 @@ describe('Selecting values', () => {
 			map: { text: 'text', value: 'win' },
 			sort: 'alphanum',
 		});
+
 		expect(wrapper.state().text[0]).to.equal('11');
 	});
 });


### PR DESCRIPTION
Updated README, and fixed two issues; In one case we've unintentionally directly mutated ComboSelect state, which caused a nasty bug where the value in ComboSelect wasn't updating correctly. Another one was related to groups, issues with selecting value too, because I was checking array of values with `contains()`  to find selected one, but when we had just a single string value that was causing an issue where values with similar names (GI and GIT, for example) were both selected, instead of just picking one.